### PR TITLE
build: drop setup_files from fi_python_package target

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -3,5 +3,4 @@ import("${workspace_firmwarecommon}/gntools/fi_python_package.gni")
 fi_python_package("fi_nrfutil") {
   lint = false
   wheel = false
-  setup_files = [ "setup.py" ]
 }


### PR DESCRIPTION
firmware-common replaces the `setup_files` list on `fi_python_package` with an optional `pyproject_toml` variable (barkinglabs/firmware-common#1049). The gen-time parse always ignored `setup.py`, so omitting the variable is equivalent — and it keeps `setup.py` out of the superproject's regeneration deps.

Land together with the firmware-common change via the superproject gitlink bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)